### PR TITLE
Add MMLU parameter analysis notebook and graph

### DIFF
--- a/ai/mmlu-params/graph.ipynb
+++ b/ai/mmlu-params/graph.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv, math\n",
+    "rows = []\n",
+    "with open('data.csv') as f:\n",
+    "    reader = csv.DictReader(f)\n",
+    "    for row in reader:\n",
+    "        mmlu = float(row['MMLU'].strip('%'))\n",
+    "        bparams = float(row['B Params'])\n",
+    "        name = row['Model']\n",
+    "        rows.append((mmlu, bparams, name))\n",
+    "\n",
+    "x_min, x_max = 0, 100\n",
+    "b_min = min(b for _, b, _ in rows if b > 0)\n",
+    "b_max = max(b for _, b, _ in rows)\n",
+    "log_y_min = math.log10(b_min)\n",
+    "log_y_max = math.log10(b_max)\n",
+    "width, height = 800, 600\n",
+    "margin = 60\n",
+    "svg = [f'<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\">']\n",
+    "svg.append(f'<line x1=\"{margin}\" y1=\"{height-margin}\" x2=\"{width-margin}\" y2=\"{height-margin}\" stroke=\"black\"/>')\n",
+    "svg.append(f'<line x1=\"{margin}\" y1=\"{height-margin}\" x2=\"{margin}\" y2=\"{margin}\" stroke=\"black\"/>')\n",
+    "for i in range(0, 101, 20):\n",
+    "    x = margin + (i - x_min)/(x_max - x_min)*(width-2*margin)\n",
+    "    svg.append(f'<line x1=\"{x}\" y1=\"{height-margin}\" x2=\"{x}\" y2=\"{height-margin-5}\" stroke=\"black\"/>')\n",
+    "    svg.append(f'<text x=\"{x}\" y=\"{height-margin+15}\" font-size=\"10\" text-anchor=\"middle\">{i}%</text>')\n",
+    "val = 1\n",
+    "while val <= b_max:\n",
+    "    if val >= b_min:\n",
+    "        log_val = math.log10(val)\n",
+    "        y = height - margin - (log_val - log_y_min)/(log_y_max - log_y_min)*(height-2*margin)\n",
+    "        svg.append(f'<line x1=\"{margin}\" y1=\"{y}\" x2=\"{margin+5}\" y2=\"{y}\" stroke=\"black\"/>')\n",
+    "        svg.append(f'<text x=\"{margin-5}\" y=\"{y+4}\" font-size=\"10\" text-anchor=\"end\">{val}</text>')\n",
+    "    val *= 10\n",
+    "for mmlu, b, name in rows:\n",
+    "    x = margin + (mmlu - x_min)/(x_max - x_min)*(width-2*margin)\n",
+    "    log_y = math.log10(b)\n",
+    "    y = height - margin - (log_y - log_y_min)/(log_y_max - log_y_min)*(height-2*margin)\n",
+    "    svg.append(f'<circle cx=\"{x}\" cy=\"{y}\" r=\"4\" fill=\"blue\"/>')\n",
+    "    svg.append(f'<text x=\"{x+5}\" y=\"{y-5}\" font-size=\"10\">{name}</text>')\n",
+    "svg.append('</svg>')\n",
+    "with open('graph.svg', 'w') as f:\n",
+    "    f.write('\\n'.join(svg))\n",
+    "print('graph.svg generated')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ai/mmlu-params/graph.svg
+++ b/ai/mmlu-params/graph.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+<line x1="60" y1="540" x2="740" y2="540" stroke="black"/>
+<line x1="60" y1="540" x2="60" y2="60" stroke="black"/>
+<line x1="60.0" y1="540" x2="60.0" y2="535" stroke="black"/>
+<text x="60.0" y="555" font-size="10" text-anchor="middle">0%</text>
+<line x1="196.0" y1="540" x2="196.0" y2="535" stroke="black"/>
+<text x="196.0" y="555" font-size="10" text-anchor="middle">20%</text>
+<line x1="332.0" y1="540" x2="332.0" y2="535" stroke="black"/>
+<text x="332.0" y="555" font-size="10" text-anchor="middle">40%</text>
+<line x1="468.0" y1="540" x2="468.0" y2="535" stroke="black"/>
+<text x="468.0" y="555" font-size="10" text-anchor="middle">60%</text>
+<line x1="604.0" y1="540" x2="604.0" y2="535" stroke="black"/>
+<text x="604.0" y="555" font-size="10" text-anchor="middle">80%</text>
+<line x1="740.0" y1="540" x2="740.0" y2="535" stroke="black"/>
+<text x="740.0" y="555" font-size="10" text-anchor="middle">100%</text>
+<line x1="60" y1="540.0" x2="65" y2="540.0" stroke="black"/>
+<text x="55" y="544.0" font-size="10" text-anchor="end">1</text>
+<line x1="60" y1="394.5908396377807" x2="65" y2="394.5908396377807" stroke="black"/>
+<text x="55" y="398.5908396377807" font-size="10" text-anchor="end">10</text>
+<line x1="60" y1="249.18167927556135" x2="65" y2="249.18167927556135" stroke="black"/>
+<text x="55" y="253.18167927556135" font-size="10" text-anchor="end">100</text>
+<line x1="60" y1="103.77251891334208" x2="65" y2="103.77251891334208" stroke="black"/>
+<text x="55" y="107.77251891334208" font-size="10" text-anchor="end">1000</text>
+<circle cx="395.24" cy="540.0" r="4" fill="blue"/>
+<text x="400.24" y="535.0" font-size="10">Llama 3.2 1B</text>
+<circle cx="244.28" cy="533.9811244060048" r="4" fill="blue"/>
+<text x="249.28" y="528.9811244060048" font-size="10">Apple OpenElm 1.1B</text>
+<circle cx="491.12" cy="470.6221989602453" r="4" fill="blue"/>
+<text x="496.12" y="465.6221989602453" font-size="10">Llama 3.2 3B</text>
+<circle cx="485.0" cy="417.1150035777697" r="4" fill="blue"/>
+<text x="490.0" y="412.1150035777697" font-size="10">Mistral 7B</text>
+<circle cx="242.24" cy="470.6221989602453" r="4" fill="blue"/>
+<text x="247.24" y="465.6221989602453" font-size="10">AppleOpenElm 3B</text>
+<circle cx="531.9200000000001" cy="408.6824432599739" r="4" fill="blue"/>
+<text x="536.9200000000001" y="403.6824432599739" font-size="10">Llama 3.1 8B</text>
+<circle cx="626.4399999999999" cy="321.1374054332898" r="4" fill="blue"/>
+<text x="631.4399999999999" y="316.1374054332898" font-size="10">Qwen2.5-32b</text>
+<circle cx="512.8799999999999" cy="408.6824432599739" r="4" fill="blue"/>
+<text x="517.8799999999999" y="403.6824432599739" font-size="10">Llama 3 8B</text>
+<circle cx="497.92" cy="408.6824432599739" r="4" fill="blue"/>
+<text x="502.92" y="403.6824432599739" font-size="10">Gemma 8B</text>
+<circle cx="544.8399999999999" cy="401.24439792049066" r="4" fill="blue"/>
+<text x="549.8399999999999" y="396.24439792049066" font-size="10">Gemma 2 9B</text>
+<circle cx="556.4" cy="388.5719640437855" r="4" fill="blue"/>
+<text x="561.4" y="383.5719640437855" font-size="10">Llama-3.2-11B</text>
+<circle cx="371.44" cy="417.1150035777697" r="4" fill="blue"/>
+<text x="376.44" y="412.1150035777697" font-size="10">Llama 2 Chat 7B</text>
+<circle cx="424.48" cy="378.022432449987" r="4" fill="blue"/>
+<text x="429.48" y="373.022432449987" font-size="10">Llama 2 Chat 13B</text>
+<circle cx="571.36" cy="331.8665968807359" r="4" fill="blue"/>
+<text x="576.36" y="326.8665968807359" font-size="10">Gemma 2 27B</text>
+<circle cx="567.96" cy="313.6993600938066" r="4" fill="blue"/>
+<text x="572.96" y="308.6993600938066" font-size="10">DBRX</text>
+<circle cx="548.9200000000001" cy="308.6446314102323" r="4" fill="blue"/>
+<text x="553.9200000000001" y="303.6446314102323" font-size="10">Mixtral Large Base</text>
+<circle cx="644.8" cy="271.7058432155504" r="4" fill="blue"/>
+<text x="649.8" y="266.7058432155504" font-size="10">Llama 3.1 70B</text>
+<circle cx="645.48" cy="269.9268411804645" r="4" fill="blue"/>
+<text x="650.48" y="264.9268411804645" font-size="10">Qwen2.5 72B</text>
+<circle cx="627.8" cy="271.7058432155504" r="4" fill="blue"/>
+<text x="632.8" y="266.7058432155504" font-size="10">Llama-3.1-Nemotron-70B-Instruct-HF</text>
+<circle cx="632.5600000000001" cy="269.9268411804645" r="4" fill="blue"/>
+<text x="637.5600000000001" y="264.9268411804645" font-size="10">Qwen2 72B</text>
+<circle cx="617.6" cy="269.9268411804645" r="4" fill="blue"/>
+<text x="622.6" y="264.9268411804645" font-size="10">NVLM-D-72B</text>
+<circle cx="600.6" cy="271.7058432155504" r="4" fill="blue"/>
+<text x="605.6" y="266.7058432155504" font-size="10">Llama 3 70B</text>
+<circle cx="597.2" cy="271.7058432155504" r="4" fill="blue"/>
+<text x="602.2" y="266.7058432155504" font-size="10">Claude 3 Sonnet</text>
+<circle cx="534.64" cy="271.7058432155504" r="4" fill="blue"/>
+<text x="539.64" y="266.7058432155504" font-size="10">LLaMA2-70B Base</text>
+<circle cx="591.76" cy="321.1374054332898" r="4" fill="blue"/>
+<text x="596.76" y="316.1374054332898" font-size="10">QwQ-32B</text>
+<circle cx="501.32" cy="331.8665968807359" r="4" fill="blue"/>
+<text x="506.32" y="326.8665968807359" font-size="10">Gemma-3-27B</text>
+<circle cx="562.5200000000001" cy="321.1374054332898" r="4" fill="blue"/>
+<text x="567.5200000000001" y="316.1374054332898" font-size="10">R1-32B</text>
+<circle cx="677.4399999999999" cy="128.96865176525029" r="4" fill="blue"/>
+<text x="682.4399999999999" y="123.96865176525029" font-size="10">Deepseek-R1</text>
+<circle cx="593.12" cy="347.737202538015" r="4" fill="blue"/>
+<text x="598.12" y="342.737202538015" font-size="10">DeepSeek-v2</text>
+<circle cx="652.28" cy="311.96910402483354" r="4" fill="blue"/>
+<text x="657.28" y="306.96910402483354" font-size="10">Deepseek-v3</text>
+<circle cx="644.8" cy="255.83523755827127" r="4" fill="blue"/>
+<text x="649.8" y="250.83523755827127" font-size="10">Llama-3.2-90B</text>
+<circle cx="536.0" cy="216.79666420715483" r="4" fill="blue"/>
+<text x="541.0" y="211.79666420715483" font-size="10">GPT-3.5</text>
+<circle cx="556.4" cy="176.9235563901421" r="4" fill="blue"/>
+<text x="561.4" y="171.9235563901421" font-size="10">Grok-1</text>
+<circle cx="595.16" cy="171.89977619822548" r="4" fill="blue"/>
+<text x="600.16" y="166.89977619822548" font-size="10">Nemotron-4-340B-Instruct</text>
+<circle cx="579.52" cy="321.1374054332898" r="4" fill="blue"/>
+<text x="584.52" y="316.1374054332898" font-size="10">QWQ-32B</text>
+<circle cx="657.04" cy="194.42394013821445" r="4" fill="blue"/>
+<text x="662.04" y="189.42394013821445" font-size="10">Qwen 3-235B</text>
+<circle cx="532.5999999999999" cy="452.45496217331595" r="4" fill="blue"/>
+<text x="537.5999999999999" y="447.45496217331595" font-size="10">Qwen3-4B</text>
+<circle cx="567.96" cy="408.6824432599739" r="4" fill="blue"/>
+<text x="572.96" y="403.6824432599739" font-size="10">Qwen3-8B</text>
+<circle cx="593.8000000000001" cy="373.3424846644277" r="4" fill="blue"/>
+<text x="598.8000000000001" y="368.3424846644277" font-size="10">Qwen3-14B</text>
+<circle cx="670.64" cy="321.1374054332898" r="4" fill="blue"/>
+<text x="675.64" y="316.1374054332898" font-size="10">Qwen3-32B</text>
+<circle cx="639.36" cy="160.85215439210396" r="4" fill="blue"/>
+<text x="644.36" y="155.85215439210396" font-size="10">Llama 3 405B</text>
+<circle cx="672.0" cy="75.69043322132893" r="4" fill="blue"/>
+<text x="677.0" y="70.69043322132893" font-size="10">Gemini Ultra</text>
+<circle cx="614.88" cy="66.65355828270992" r="4" fill="blue"/>
+<text x="619.88" y="61.65355828270992" font-size="10">GPT-04-mini</text>
+<circle cx="623.72" cy="66.65355828270992" r="4" fill="blue"/>
+<text x="628.72" y="61.65355828270992" font-size="10">GPT-o3</text>
+<circle cx="663.16" cy="66.65355828270992" r="4" fill="blue"/>
+<text x="668.16" y="61.65355828270992" font-size="10">GPT-4o</text>
+<circle cx="647.5200000000001" cy="66.65355828270992" r="4" fill="blue"/>
+<text x="652.5200000000001" y="61.65355828270992" font-size="10">GPT-4</text>
+<circle cx="650.24" cy="60.0" r="4" fill="blue"/>
+<text x="655.24" y="55.0" font-size="10">Claude 3 Opus</text>
+<circle cx="666.5600000000001" cy="195.2250129852245" r="4" fill="blue"/>
+<text x="671.5600000000001" y="190.2250129852245" font-size="10">Qwen3-235B</text>
+</svg>

--- a/ai/mmlu-params/index.md
+++ b/ai/mmlu-params/index.md
@@ -1,0 +1,3 @@
+# MMLU Parameters vs Score
+
+![MMLU vs Parameters](graph.svg)


### PR DESCRIPTION
## Summary
- add Jupyter notebook to parse MMLU CSV and produce scatter plot
- render log-scale params vs MMLU scores into SVG image
- expose generated graph via simple index page

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ee9b5510832d80d54655cfc64f20